### PR TITLE
Get all subtypes in a hierarchy

### DIFF
--- a/src/upt/se/arguments/pair/AllPossibleArgumentsTypes.java
+++ b/src/upt/se/arguments/pair/AllPossibleArgumentsTypes.java
@@ -23,12 +23,15 @@ public class AllPossibleArgumentsTypes implements IRelationBuilder<MClassPair, M
   public Group<MClassPair> buildGroup(MParameterPair entity) {
     return Try.of(() -> entity.getUnderlyingObject())
         .map(parameterPair -> Tuple.of(parameterPair.getFirst(), parameterPair.getSecond()))
-        .map(parameterPair -> parameterPair.map(Factory.getInstance()::createMParameter,
-            Factory.getInstance()::createMParameter))
-        .map(mParameterPair -> mParameterPair.map(MParameter::allPossibleArgumentTypes,
-            MParameter::allPossibleArgumentTypes))
-        .map(allArgumentTypesPair -> allArgumentTypesPair.map(GroupBuilder::unwrapArguments,
-            GroupBuilder::unwrapArguments))
+        .map(parameterPair -> parameterPair
+            .map(Factory.getInstance()::createMParameter,
+                Factory.getInstance()::createMParameter))
+        .map(mParameterPair -> mParameterPair
+            .map(MParameter::allPossibleArgumentTypes,
+                MParameter::allPossibleArgumentTypes))
+        .map(allArgumentTypesPair -> allArgumentTypesPair
+            .map(GroupBuilder::unwrapArguments,
+                GroupBuilder::unwrapArguments))
         .map(allArgumentTypesPair -> allArgumentTypesPair.map(List::ofAll, List::ofAll))
         .map(allArgumentTypesPair -> allArgumentTypesPair
             .apply((firstSubtypes, secondSubtypes) -> firstSubtypes.crossProduct(secondSubtypes)))

--- a/src/upt/se/arguments/single/AllPossibleArgumentTypes.java
+++ b/src/upt/se/arguments/single/AllPossibleArgumentTypes.java
@@ -50,7 +50,7 @@ public class AllPossibleArgumentTypes implements IRelationBuilder<MClass, MParam
     return Try.of(() -> type)
         .map(superType -> (IType) superType.getJavaElement())
         .mapTry(superType -> Tuple.of(superType,
-            List.of(superType.newTypeHierarchy(NULL_PROGRESS_MONITOR).getSubtypes(superType))))
+            List.of(superType.newTypeHierarchy(NULL_PROGRESS_MONITOR).getAllSubtypes(superType))))
         .map(types -> types.apply((rootType, subTypes) -> subTypes.prepend(rootType)))
         .map(types -> types.sortBy(subType -> subType.getFullyQualifiedName()))
         .onFailure(exception -> LOGGER.log(Level.SEVERE,

--- a/src/upt/se/utils/crawlers/InheritanceArgumentTypes.java
+++ b/src/upt/se/utils/crawlers/InheritanceArgumentTypes.java
@@ -17,7 +17,7 @@ public class InheritanceArgumentTypes {
   public static List<ITypeBinding> getAllSubtypes(ITypeBinding typeBinding) {
     return Try.of(() -> (IType) typeBinding.getJavaElement())
         .mapTry(type -> type.newTypeHierarchy(NULL_PROGRESS_MONITOR)
-            .getSubtypes(type))
+            .getAllSubtypes(type))
         .map(List::of)
         .flatMap(subTypes -> convert(subTypes).toTry())
         .onFailure(t -> LOGGER.log(Level.SEVERE, "An error has occurred", t))

--- a/src/upt/se/utils/helpers/Converter.java
+++ b/src/upt/se/utils/helpers/Converter.java
@@ -17,7 +17,6 @@ public final class Converter {
   }
 
   public static final Option<List<ITypeBinding>> convert(List<IType> types) {
-    System.out.println(types.filter(type -> type.getCompilationUnit() == null).mkString("\n"));
     return types.foldLeft(Option.some(List.empty()),
         (res, type) -> convert(type).onEmpty(() -> LOGGER.log(Level.SEVERE,
             "An error occurred while trying to get all the parameters for: "

--- a/src/upt/se/utils/visitors/ITypeConverter.java
+++ b/src/upt/se/utils/visitors/ITypeConverter.java
@@ -22,8 +22,9 @@ public class ITypeConverter extends ASTVisitor {
     IBinding binding = node.resolveBinding();
     if (binding instanceof ITypeBinding) {
       ITypeBinding type = (ITypeBinding) binding;
-      if (isEqual(searchedType, type) && !type.isRawType() && type.isGenericType()) {
+      if (isEqual(searchedType, type) && !type.isRawType()) {
         typeBinding = type;
+        throw new TypeFound();
       }
     }
     return super.visit(node);
@@ -36,9 +37,16 @@ public class ITypeConverter extends ASTVisitor {
   public static Option<ITypeBinding> convert(IType type) {
     ITypeConverter self = new ITypeConverter(type);
 
-    CompilationUnit cUnit = (CompilationUnit) Parser.parse(type.getCompilationUnit());
-    cUnit.accept(self);
+    try {
+      CompilationUnit cUnit = (CompilationUnit) Parser.parse(type.getCompilationUnit());
+      cUnit.accept(self);
+    } catch (TypeFound e) {
+      return self.getTypeBinding();
+    }
+    return Option.none();
+  }
 
-    return self.getTypeBinding();
+  @SuppressWarnings("serial")
+  class TypeFound extends RuntimeException {
   }
 }


### PR DESCRIPTION
To have a more complete image of the analyzed code, the tool must first get all the subtypes of a type. 

The previous implementation only returned the types which directly extended the analyzed class. 

This PR enables the tool to return all the types which are part of the analyzed class hierarchy